### PR TITLE
Improve handling dead socket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ GitHub-Flask==3.2.0
 gunicorn==20.0.4
 mock==3.0.5
 PyGithub==1.51
-pytest==5.4.2
+pytest==5.4.3
 pytest-pythonpath==0.7.3
-pytest-cov==2.8.1
-requests==2.23.0
+pytest-cov==2.10.0
+requests==2.24.0

--- a/src/server.py
+++ b/src/server.py
@@ -206,7 +206,8 @@ def ws_admin_logs(ws):
             try:
                 ws.send(decoded_line + '\n')
             except Exception as e:
-                logging.exception(e)
+                logging.error(dir(e))
+                logging.error('/admin/logs ws.send() exception {}'.format(e))
                 break
 
     logging.info('websocket connection ended')


### PR DESCRIPTION
When the client socket on `/admin/logs` is dead (MSG_SOCKET_DEAD)
the complete exception is logged. Better handle the case and better
log output.