### PR TITLE
Remove handling of `WIP` PR or label

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Github Pull Request are the main contact point. Reviewing a PR with an
 
 The number of commits on the repository is the weight for the vote.
 
-PRs can be ignore by prefixing the title with `[WIP] `.
-
 If a PR is ready for merge a voting is started (starting `value` 0):
  - If a reviewer 'Request changes' the `value` decreases by their contribution value.
  - If a reviewer 'Approve' the `value` increases by their contribution value.


### PR DESCRIPTION
Before a prefix of `[WIP]` would stop auto merge. Github introduced
`Draft` Pull Request, using this functionality instead (tbd).