### PR TITLE
Introducing `worlddriven.ini`

### DIFF
--- a/.worlddriven.ini-example
+++ b/.worlddriven.ini-example
@@ -1,0 +1,3 @@
+[DEFAULT]
+baseMergeTimeInHours = 120
+perCommitTimeInHours = 120

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/a3385a0433a649be95639b8a59fcb6fe)](https://www.codacy.com/app/TooAngel/worlddriven?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=TooAngel/worlddriven&amp;utm_campaign=Badge_Grade)
 [![CircleCI](https://circleci.com/gh/TooAngel/worlddriven.svg?style=svg)](https://circleci.com/gh/TooAngel/worlddriven)
-[![discord](https://www.worlddriven.org/static/images/Discord-Logo-Black.png)](https://discord.gg/RrGFHKb)
+[![discord](https://discord.com/assets/94db9c3c1eba8a38a1fcf4f223294185.png)](https://discord.gg/RrGFHKb)
 [![Code climate](https://api.codeclimate.com/v1/badges/ec4136b6d2eeff72f192/maintainability)](https://codeclimate.com/github/TooAngel/worlddriven/maintainability)
 
 Hosted under https://www.worlddriven.org
@@ -27,10 +27,20 @@ Set Session secret as `SESSION_SECRET` initial a random string.
 Run tests with: `pytest`
 
 ### Install via docker compose
+
 Copy `.env-example` to `.env` and add your environment variables.
 ```sh
 docker-compose up
 ```
+
+## Configuration
+
+To allow different configurations on different repositories you can place a
+`.worlddriven.ini` (see `.worlddriven.ini-example`) in the root of your
+repository and adapt the values.
+When worlddriven checks new Pull Requests it fetches the `.worlddriven.ini` from
+your default branch (fetching from the Pull Request could be a security issue)
+and applies the configuration.
 
 ## Production environment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 APScheduler==3.6.3
 codacy-coverage==1.3.11
+configparser==4.0.2
 coverage==4.5.1
 Flask==1.1.2
 Flask-Compress==1.5.0

--- a/tests/test_pullRequest.py
+++ b/tests/test_pullRequest.py
@@ -1,0 +1,77 @@
+import PullRequest
+import unittest
+from mock import patch, MagicMock
+from datetime import datetime, timedelta
+
+
+class PullRequestTestCase(unittest.TestCase):
+
+    @patch('PullRequest.MongoClient')
+    @patch('PullRequest.logging')
+    @patch('PullRequest.fetch_reviews')
+    @patch('PullRequest.github')
+    def test_config(self, github, fetch_reviews, logging, mongoClient):
+        contributor_author = MagicMock()
+        contributor_author.login = 'reviewer'
+
+        contributor = MagicMock()
+        contributor.author = contributor_author
+        contributor.total = 1
+
+        contributor_2nd_author = MagicMock()
+        contributor_2nd_author.login = '2nd'
+
+        contributor_2nd = MagicMock()
+        contributor_2nd.author = contributor_2nd_author
+        contributor_2nd.total = 1
+
+        repository = MagicMock()
+        repository.get_stats_contributors.return_value = [contributor, contributor_2nd]
+
+        fetch_reviews.return_value = [
+            {
+                'state': 'APPROVED',
+                'submitted_at': datetime.now() - timedelta(days=2),
+                'user': {
+                    'login': 'reviewer'
+                }
+            }
+        ]
+
+        user = MagicMock()
+        user.login = 'login'
+        user.date = 5
+
+        commit = MagicMock()
+        commit.author = user
+        commit.commit.author.date = datetime.now() - timedelta(days=3)
+
+        commits = MagicMock()
+        commits.reversed = [commit]
+
+        pull_request = MagicMock()
+        pull_request.get_commits.return_value = commits
+        pull_request.title = 'title'
+        pull_request.user = user
+        pull_request.commits = 1
+        pull_request.created_at = datetime.now() - timedelta(days=4)
+
+        commentOnIssue = False
+        token = ''
+
+        # Do not merge with default config
+        pr = PullRequest.check_pull_request(repository, pull_request, commentOnIssue, token)
+        assert not pull_request.merge.called
+
+        # Merge with updated config
+        repository.get_contents.return_value = """
+[DEFAULT]
+baseMergeTimeInHours = 20
+perCommitTimeInHours = 20
+"""
+        pr = PullRequest.check_pull_request(repository, pull_request, commentOnIssue, token)
+        assert pull_request.merge.called
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A `worlddriven.ini` can be placed in the root of the repository to
configure the merge times.
Current options are `baseMergeTimeInHours` and `perCommitTimeInHours`.
The config is fetched from the default branch of the repository and
applied.

Fixes #154