### PR TITLE
Fix reading of config file

### DIFF
--- a/src/PullRequest.py
+++ b/src/PullRequest.py
@@ -35,10 +35,12 @@ class PullRequest(object):
         try:
             config_file_content = repository.get_contents(".worlddriven.ini")
             config = configparser.ConfigParser()
-            config.read_string(config_file_content)
-            self.config['baseMergeTimeInHours'] = float(config['DEFAULT'].get('baseMergeTimeInHours', self.config['baseMergeTimeInHours']))
-            self.config['perCommitTimeInHours'] = float(config['DEFAULT'].get('perCommitTimeInHours', self.config['perCommitTimeInHours']))
-            self.config['merge_method'] = float(config['DEFAULT'].get('merge_method', self.config['merge_method']))
+            config.read_string(config_file_content.decoded_content.decode('utf-8'))
+            config_new = {}
+            config_new['baseMergeTimeInHours'] = float(config['DEFAULT'].get('baseMergeTimeInHours'))
+            config_new['perCommitTimeInHours'] = float(config['DEFAULT'].get('perCommitTimeInHours'))
+            config_new['merge_method'] = config['DEFAULT'].get('merge_method')
+            self.config.update(config_new)
         except Exception as e:
             logging.info('No config file found')
 

--- a/tests/test_pullRequest.py
+++ b/tests/test_pullRequest.py
@@ -63,12 +63,16 @@ class PullRequestTestCase(unittest.TestCase):
         pr = PullRequest.check_pull_request(repository, pull_request, commentOnIssue, token)
         assert not pull_request.merge.called
 
-        # Merge with updated config
-        repository.get_contents.return_value = """
+        content = MagicMock()
+        content.decoded_content = b"""
 [DEFAULT]
 baseMergeTimeInHours = 20
 perCommitTimeInHours = 20
 """
+
+        # Merge with updated config
+        repository.get_contents.return_value = content
+
         pr = PullRequest.check_pull_request(repository, pull_request, commentOnIssue, token)
         assert pull_request.merge.called
 


### PR DESCRIPTION
The content of a GitHub file is accessible via `decoded_content`.
Also improve merging of the configs.