### PR TITLE
Reduce noise

### DIFF
--- a/src/routes/githubWebHook.py
+++ b/src/routes/githubWebHook.py
@@ -91,7 +91,9 @@ Check the `worlddriven` status check or the [dashboard]({}) for actual stats.
         logging.info('execute_edited {}'.format(self.data))
 
     def execute_closed(self):
-        logging.info('execute_closed {}'.format(self.data))
+        # Don't know if we need to do something here
+        # logging.info('execute_closed {}'.format(self.data))
+        pass
 
 
 class GithubWebHook(flask_restful.Resource):

--- a/src/server.py
+++ b/src/server.py
@@ -78,8 +78,6 @@ def before_request():
     if 'user_id' in session:
         user = mongo.db.users.find_one({'_id': ObjectId(session['user_id'])})
         g.user = user
-    else:
-        logging.info('no user in session')
 
 
 @github_oauth.access_token_getter

--- a/tests/test_routes_githubWebHook_pull_request.py
+++ b/tests/test_routes_githubWebHook_pull_request.py
@@ -218,7 +218,6 @@ Check the `worlddriven` status check or the [dashboard](https://www.worlddriven.
         response = json.loads(rv.data.decode('utf-8'))
 
         self.assertEqual('All fine, thanks', response['info'])
-        logging.info.assert_called_with("execute_closed {'action': 'closed'}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Remove `no user in session` message
- Remove GitHub webhook closed noise

Both messages spam the log and are not helpful in any way.