### PR TITLE
Show PullRequests on the dashboard

### DIFF
--- a/src/public/js/dashboard.js
+++ b/src/public/js/dashboard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Repository} from './repository'; // eslint-disable-line no-unused-vars
+import {PullRequestView} from './pullrequestView'; // eslint-disable-line no-unused-vars
 
 /**
  * Dashboard class
@@ -18,6 +19,8 @@ export class Dashboard extends React.Component { // eslint-disable-line no-unuse
       repositories: [],
       fetched: false,
     };
+
+    this.setPullRequest = this.setPullRequest.bind(this);
   }
 
   /**
@@ -119,6 +122,16 @@ export class Dashboard extends React.Component { // eslint-disable-line no-unuse
   }
 
   /**
+   * setPullRequest - Sets the data of a pull request to the state
+   *
+   * @param {object} pullRequest - The Pull Request data
+   * @return {void}
+   **/
+  setPullRequest(pullRequest) {
+    this.setState({pullRequest: pullRequest});
+  }
+
+  /**
    * render - renders
    * @return {object} - The element to be renderd
    **/
@@ -133,7 +146,14 @@ export class Dashboard extends React.Component { // eslint-disable-line no-unuse
 
     const repositories = [];
     for (const repository of this.state.repositories) {
-      repositories.push(<Repository key={repository.full_name} repository={repository} getPullRequest={this.getPullRequest} />);
+      repositories.push(<Repository key={repository.full_name} repository={repository} getPullRequest={this.getPullRequest} setPullRequest={this.setPullRequest}/>);
+    }
+
+    let main = <div>Here you can enable world driven for each of your repositories. When
+    enabled pull requests are watched and automatically merged based on the
+    reviews.</div>;
+    if (this.state.pullRequest) {
+      main = <PullRequestView pullRequest={this.state.pullRequest} />;
     }
 
     return (
@@ -147,13 +167,15 @@ export class Dashboard extends React.Component { // eslint-disable-line no-unuse
           </div>
         </div>
         <h1>{ this.state.user }</h1>
-        Here you can enable world driven for each of your repositories. When
-        enabled pull requests are watched and automatically emerged based on the
-        reviews.
         <div className="main-content">
-          <h2>Repositories</h2>
-          <div className="repositories">
-            { repositories }
+          <div className="gridFirst">
+            <h2>Repositories</h2>
+            <div className="repositories">
+              {repositories}
+            </div>
+          </div>
+          <div className="gridSecond">
+            {main}
           </div>
         </div>
       </div>

--- a/src/public/js/pullrequest.js
+++ b/src/public/js/pullrequest.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {PullRequestView} from './pullrequestView'; // eslint-disable-line no-unused-vars
+
 /**
  * PullRequest class
  **/
@@ -48,21 +50,6 @@ export class PullRequest extends React.Component { // eslint-disable-line no-unu
   }
 
   /**
-   * getTimeDeltaString - converts seconds to an output string
-   *
-   * @param {number} value - The value which helds the timedelta
-   * @return {string} - The formatted output
-   **/
-  getTimeDeltaString(value) {
-    const days = Math.floor(value / 86400);
-    const daysRemainer = value % 86400;
-    const hours = Math.floor(daysRemainer / 3600);
-    const hoursRemainer = daysRemainer % 3600;
-    const minutes = Math.floor(hoursRemainer / 60);
-    return `${days} ${days === 1 ? 'day' : 'days'} ${hours} ${hours === 1 ? 'hour': 'hours'} ${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
-  }
-
-  /**
    * render - renders
    * @return {object} - The element to be renderd
    **/
@@ -70,76 +57,6 @@ export class PullRequest extends React.Component { // eslint-disable-line no-unu
     if (!this.state.fetched) {
       return <div className="loader"></div>;
     }
-    const style = {
-      height: '100%',
-    };
-
-    const headerStyle = {color: 'grey'};
-
-    const contributors = [];
-    for (const contributor of this.state.pullRequest.stats.contributors) {
-      contributors.push(<tr key={contributor.name} className={`review_value${contributor.review_value}` }>
-        <td>{ contributor.name }</td>
-        <td>{ contributor.commits }</td>
-        <td>{ this.getTimeDeltaString(contributor.time_value) }</td>
-      </tr>);
-    }
-
-    const githubPullRequestLink = `https://github.com/${this.state.pullRequest.org}/${this.state.pullRequest.repo}/pull/${this.state.pullRequest.number}`;
-
-    return (
-      <div style={style}>
-        <h1><a href={githubPullRequestLink}>{ this.state.pullRequest.title } <span style={headerStyle}>#{ this.state.pullRequest.number }</span></a></h1>
-        <span className="PullRequestSummary">repository: { this.state.pullRequest.org }/{ this.state.pullRequest.repo }</span> <br />
-        <span className="PullRequestSummary">state: { this.state.pullRequest.state }</span>
-
-        <details>
-          <summary className="PullRequestSummary"><span title="The point in time when the countdown starts">Start date: { new Date(this.state.pullRequest.dates.max * 1000 || 0).toISOString() }</span></summary>
-          <table>
-            <tbody>
-              <tr title="The date when the labels changed"><td>Unlabel date:</td><td>{ new Date(this.state.pullRequest.dates.unlabel * 1000 || 0).toISOString() }</td></tr>
-              <tr title="The last date it was pushed"><td>Push date:</td><td>{ new Date(this.state.pullRequest.dates.push * 1000 || 0).toISOString() }</td></tr>
-              <tr title="The last date of the commits"><td>Commit date:</td><td>{ new Date(this.state.pullRequest.dates.commit * 1000 || 0).toISOString() }</td></tr>
-              <tr title="The last date it was ready for Review"><td>Ready For Review date:</td><td>{ new Date(this.state.pullRequest.dates.last_draft * 1000 || 0).toISOString() }</td></tr>
-              <tr title="The date when the pull request was opened"><td>Pull Request date:</td><td>{ new Date(this.state.pullRequest.dates.created * 1000 || 0).toISOString() }</td></tr>
-              <tr><td><hr/></td><td><hr/></td></tr>
-              <tr title="The start date is the most recent one from the above"><td>Start date:</td><td>{ new Date(this.state.pullRequest.dates.max * 1000 || 0).toISOString() }</td></tr>
-            </tbody>
-          </table>
-        </details>
-
-        <details>
-          <summary className="PullRequestSummary"><span title="Pull Request reviews counted as votes">Positive votes: { this.state.pullRequest.stats.votes }/{ this.state.pullRequest.stats.votes_total }</span></summary>
-          <table>
-            <tbody>
-              <tr><td title="Number of votes due to pull request reviews">votes:</td><td>{ this.state.pullRequest.stats.votes }</td></tr>
-              <tr><td title="The total number of votes (commits)">votes_total:</td><td>{ this.state.pullRequest.stats.votes_total }</td></tr>
-              <tr><td title="The factor by which the total merge days are reduced">coefficient:</td><td>{ this.state.pullRequest.stats.coefficient }</td></tr>
-            </tbody>
-          </table>
-          <table>
-            <tbody>
-              <tr><td><b>name</b></td><td>commits</td><td>merge boost</td></tr>
-              { contributors }
-            </tbody>
-          </table>
-        </details>
-
-        <details>
-          <summary className="PullRequestSummary">
-            <span title="The Pull Request will be automatically merged in">Time to merge: {this.getTimeDeltaString(this.state.pullRequest.times.days_to_merge.total_seconds)} ({ new Date(this.state.pullRequest.times.merge_date * 1000 || 0).toISOString() })</span>
-          </summary>
-          <table>
-            <tbody>
-              <tr><td title="For each commit the duration is extended by 5 days">Commits:</td><td>{ this.state.pullRequest.stats.commits }</td></tr>
-              <tr><td title="The total time until the Pull Request is merged. 5 days + commit days">Total duration:</td><td>{ this.state.pullRequest.times.total_merge_time }</td></tr>
-              <tr><td title="Total merge days multiplied by the voting coefficient to get the actual duration.">Reduce to:</td><td>{this.getTimeDeltaString(this.state.pullRequest.times.merge_duration.total_seconds)}</td></tr>
-              <tr><td title="How old is the pull request, based on max date">Age:</td><td>{this.getTimeDeltaString(this.state.pullRequest.stats.age.total_seconds)}</td></tr>
-            </tbody>
-          </table>
-        </details>
-
-      </div>
-    );
+    return <PullRequestView pullRequest={this.state.pullRequest} />;
   }
 }

--- a/src/public/js/pullrequestView.js
+++ b/src/public/js/pullrequestView.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * PullRequest class
+ **/
+export class PullRequestView extends React.Component { // eslint-disable-line no-unused-vars
+  /**
+   * contructor - The constructor
+   *
+   * @param {object} props - The properties
+   * @return {void}
+   **/
+  constructor(props) {
+    super(props);
+  }
+
+  /**
+   * getTimeDeltaString - converts seconds to an output string
+   *
+   * @param {number} value - The value which helds the timedelta
+   * @return {string} - The formatted output
+   **/
+  getTimeDeltaString(value) {
+    const days = Math.floor(value / 86400);
+    const daysRemainer = value % 86400;
+    const hours = Math.floor(daysRemainer / 3600);
+    const hoursRemainer = daysRemainer % 3600;
+    const minutes = Math.floor(hoursRemainer / 60);
+    return `${days} ${days === 1 ? 'day' : 'days'} ${hours} ${hours === 1 ? 'hour': 'hours'} ${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
+  }
+
+  /**
+   * render - renders
+   * @return {object} - The element to be renderd
+   **/
+  render() {
+    const style = {
+      height: '100%',
+    };
+    const headerStyle = {color: 'grey'};
+
+    const contributors = [];
+    for (const contributor of this.props.pullRequest.stats.contributors) {
+      contributors.push(<tr key={contributor.name} className={`review_value${contributor.review_value}` }>
+        <td>{ contributor.name }</td>
+        <td>{ contributor.commits }</td>
+        <td>{ this.getTimeDeltaString(contributor.time_value) }</td>
+      </tr>);
+    }
+
+    const githubPullRequestLink = `https://github.com/${this.props.pullRequest.org}/${this.props.pullRequest.repo}/pull/${this.props.pullRequest.number}`;
+    return (
+      <div style={style}>
+        <h1><a href={githubPullRequestLink}>{ this.props.pullRequest.title } <span style={headerStyle}>#{ this.props.pullRequest.number }</span></a></h1>
+        <span className="PullRequestSummary">repository: { this.props.pullRequest.org }/{ this.props.pullRequest.repo }</span> <br />
+        <span className="PullRequestSummary">state: { this.props.pullRequest.state }</span>
+
+        <details>
+          <summary className="PullRequestSummary"><span title="The point in time when the countdown starts">Start date: { new Date(this.props.pullRequest.dates.max * 1000 || 0).toISOString() }</span></summary>
+          <table>
+            <tbody>
+              <tr title="The date when the labels changed"><td>Unlabel date:</td><td>{ new Date(this.props.pullRequest.dates.unlabel * 1000 || 0).toISOString() }</td></tr>
+              <tr title="The last date it was pushed"><td>Push date:</td><td>{ new Date(this.props.pullRequest.dates.push * 1000 || 0).toISOString() }</td></tr>
+              <tr title="The last date of the commits"><td>Commit date:</td><td>{ new Date(this.props.pullRequest.dates.commit * 1000 || 0).toISOString() }</td></tr>
+              <tr title="The last date it was ready for Review"><td>Ready For Review date:</td><td>{ new Date(this.state.pullRequest.dates.last_draft * 1000 || 0).toISOString() }</td></tr>
+              <tr title="The date when the pull request was opened"><td>Pull Request date:</td><td>{ new Date(this.props.pullRequest.dates.created * 1000 || 0).toISOString() }</td></tr>
+              <tr><td><hr/></td><td><hr/></td></tr>
+              <tr title="The start date is the most recent one from the above"><td>Start date:</td><td>{ new Date(this.props.pullRequest.dates.max * 1000 || 0).toISOString() }</td></tr>
+            </tbody>
+          </table>
+        </details>
+
+        <details>
+          <summary className="PullRequestSummary"><span title="Pull Request reviews counted as votes">Positive votes: { this.props.pullRequest.stats.votes }/{ this.props.pullRequest.stats.votes_total } (~{ Math.round(this.props.pullRequest.stats.votes / this.props.pullRequest.stats.votes_total * 100) } %)</span></summary>
+          <table>
+            <tbody>
+              <tr><td title="Number of votes due to pull request reviews">votes:</td><td>{ this.props.pullRequest.stats.votes }</td></tr>
+              <tr><td title="The total number of votes (commits)">votes_total:</td><td>{ this.props.pullRequest.stats.votes_total }</td></tr>
+              <tr><td title="The factor by which the total merge days are reduced">coefficient:</td><td>{ this.props.pullRequest.stats.coefficient }</td></tr>
+            </tbody>
+          </table>
+          <table>
+            <tbody>
+              <tr><td><b>name</b></td><td>commits</td><td>merge boost</td></tr>
+              { contributors }
+            </tbody>
+          </table>
+        </details>
+
+        <details>
+          <summary className="PullRequestSummary">
+            <span title="The Pull Request will be automatically merged in">Time to merge: {this.getTimeDeltaString(this.props.pullRequest.times.days_to_merge.total_seconds)} ({ new Date(this.props.pullRequest.times.merge_date * 1000 || 0).toISOString() })</span>
+          </summary>
+          <table>
+            <tbody>
+              <tr><td title="For each commit the duration is extended by 5 days">Commits:</td><td>{ this.props.pullRequest.stats.commits }</td></tr>
+              <tr><td title="The total time until the Pull Request is merged. 5 days + commit days">Total duration:</td><td>{ this.props.pullRequest.times.total_merge_time }</td></tr>
+              <tr><td title="Total merge days multiplied by the voting coefficient to get the actual duration.">Reduce to:</td><td>{this.getTimeDeltaString(this.props.pullRequest.times.merge_duration.total_seconds)}</td></tr>
+              <tr><td title="How old is the pull request, based on max date">Age:</td><td>{this.getTimeDeltaString(this.props.pullRequest.stats.age.total_seconds)}</td></tr>
+            </tbody>
+          </table>
+        </details>
+
+      </div>
+    );
+  }
+}
+
+PullRequestView.propTypes = {
+  pullRequest: PropTypes.object.isRequired,
+};

--- a/src/public/js/repository.js
+++ b/src/public/js/repository.js
@@ -18,6 +18,7 @@ export class Repository extends React.Component { // eslint-disable-line no-unus
       this.state[pullRequest.title] = {fetched: false};
     }
     this.handleChange = this.handleChange.bind(this);
+    this.selectPullRequest= this.selectPullRequest.bind(this);
   }
 
   /**
@@ -33,6 +34,17 @@ export class Repository extends React.Component { // eslint-disable-line no-unus
         this.setState({[pullRequestData.title]: pullRequestData});
       });
     });
+  }
+
+  /**
+   * selectPullRequest - selects a pull request
+   *
+   * @param {object} event - the click event
+   * @param {string} pullRequestTitle - The title of a pull request
+   * @return {void}
+   **/
+  selectPullRequest(event, pullRequestTitle) {
+    this.props.setPullRequest(this.state[pullRequestTitle]);
   }
 
   /**
@@ -70,12 +82,18 @@ export class Repository extends React.Component { // eslint-disable-line no-unus
         if (pullRequestData.stats.coefficient > 0) {
           className = 'pullRequestLine green';
           title = 'Will be merged automatically';
-          content = <div className="pullRequestListItem"><div>{pullRequestData.title}</div><div>merge on {new Date(pullRequestData.times.merge_date * 1000 || 0).toISOString()}</div></div>;
+          content = <div className="pullRequestListItem">
+            <div>
+              <div>{pullRequestData.title}</div>
+              <div>merge</div>
+            </div>
+            <div>{new Date(pullRequestData.times.merge_date * 1000 || 0).toISOString().replace('T', ' ').replace('.000Z', ' UTC')}</div>
+          </div>;
         }
       }
-      pullRequests.push(<li key={pullRequestData.title} className={className} title={title}>{content}</li>);
+      pullRequests.push(<li key={pullRequestData.title} className={className} title={title} onClick={(e) => this.selectPullRequest(e, pullRequestData.title)}>{content}</li>);
     }
-    const pullRequestsTag = <ul>{pullRequests}</ul>;
+    const pullRequestsTag = <div className="repositoryList"><ul>{pullRequests}</ul></div>;
 
     return (<div key={this.props.repository.full_name} className="repository">
       <div className="repositoryName">{this.props.repository.full_name}</div>
@@ -94,4 +112,5 @@ export class Repository extends React.Component { // eslint-disable-line no-unus
 Repository.propTypes = {
   repository: PropTypes.object,
   getPullRequest: PropTypes.func,
+  setPullRequest: PropTypes.func,
 };

--- a/src/public/js/test/dashboard.js
+++ b/src/public/js/test/dashboard.js
@@ -49,13 +49,37 @@ export class TestDashboard extends Dashboard { // eslint-disable-line no-unused-
    **/
   getPullRequest(repositoryFullName, pullRequestNumber, callback) {
     callback({pull_request: {
-      title: 'pull request title',
+      title: 'Some cool new feature',
       mergeable: true,
       stats: {
+        contributors: [
+          {
+            name: 'contributor',
+            review_value: 5,
+            commits: '4',
+            time_value: 7,
+          },
+        ],
+        age: {},
         coefficient: 0.3,
+        votes: 7,
+        votes_total: 12,
+      },
+      org: 'testorg',
+      repo: 'testrepo',
+      number: 5,
+      state: 'state',
+      dates: {
+        max: 123456789,
       },
       times: {
-        merge_date: 1234567,
+        days_to_merge: {
+          merge_date: 1234567,
+
+        },
+        merge_duration: {
+
+        },
       },
     }});
   }

--- a/src/public/js/test/pullrequest.js
+++ b/src/public/js/test/pullrequest.js
@@ -21,6 +21,8 @@ export class TestPullRequest extends PullRequest { // eslint-disable-line no-unu
           },
         ],
         age: {},
+        votes: 7,
+        votes_total: 12,
       },
       org: 'testorg',
       repo: 'testrepo',

--- a/static/index.html
+++ b/static/index.html
@@ -116,6 +116,8 @@
     <p>Next time Alice, due to her now merged contributions, has the ability to vote on any future Pull Requests.
     This means she can have some responsibility over the progress of the project.</p>
 
+    <p>Of course, if 100% vote for a Pull Request it is merged directly.</p>
+
 
     <h4>Current Status</h4>
     <p>The auto-merger is working on itself and a couple of other projects as well;

--- a/static/style.css
+++ b/static/style.css
@@ -171,8 +171,8 @@ li h4 {
 .switch {
   position: relative;
   display: inline-block;
-  width: 60px;
-  height: 34px;
+  width: 52px;
+  height: 28px;
 }
 
 /* Hide default HTML checkbox */
@@ -198,8 +198,8 @@ li h4 {
 .slider:before {
   position: absolute;
   content: "";
-  height: 26px;
-  width: 26px;
+  height: 20px;
+  width: 20px;
   left: 4px;
   bottom: 4px;
   background-color: white;
@@ -275,7 +275,7 @@ input:checked + .slider:before {
 }
 
 .repositoryName {
-  font-size: 1.5em;
+  font-size: 1.3em;
 }
 
 .pullRequestLine {
@@ -304,4 +304,20 @@ input:checked + .slider:before {
 
 .challenge-bullets h4 {
   margin-bottom: 0;
+}
+
+.main-content {
+  display: grid;
+}
+
+.gridFirst {
+  grid-column: 1;
+}
+
+.gridSecond {
+  grid-column: 2 / span 2;
+}
+
+.repositoryList {
+  grid-column: 1 / 3;
 }


### PR DESCRIPTION
Before on the dashboard only the repositories were shown with a checkbox
to enable World Driven and a list of Pull Requests.

Now a Pull Request can be selected and the details of the Pull Request
are shown.

This is in many regards (styling, code structure, ...) not close to
optimal, but it improves the current dashboard.

Next steps:

- Look into ways to include component css into the component
- Change the 'routing', put pull requests under `/dashboard`
(`/dashboard/:org/:repo/pull/:pull_number`) also change when selecting
PR. Get rid of the custom Pull Request logic.
- Better naming of components