### PR TITLE
Add Ping to websocket connections

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "ignore": ["tmp/*", "dist/*"],
+  "ignore": ["tmp/*", "dist/*", "*.py", "*.pyc"],
   "delay": "2500",
   "ext": "*",
   "events": {

--- a/src/public/js/logs.js
+++ b/src/public/js/logs.js
@@ -33,7 +33,8 @@ export class Logs extends React.Component { // eslint-disable-line no-unused-var
    * @return {void}
    **/
   initWS() {
-    this.ws = new WebSocket(`ws://localhost:8000/admin/logs`);
+    const url = `ws://${window.location.hostname}:${window.location.port}/admin/logs`;
+    this.ws = new WebSocket(url);
     this.ws.onopen = () => {
       console.log('connected');
     };

--- a/static/index.html
+++ b/static/index.html
@@ -211,7 +211,7 @@
   <footer>
     <a href="/imprint">Imprint</a>
     <a href="/privacyPolicy">Privacy Policy</a>
-    <a href='/admin/logs'>Public Admin</a>
+    <a href='/admin'>Public Admin</a>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
Heroku drops connections which are idle for too long. Sending a regular
ping to make sure the websocket connection stays alive.