### PR TITLE
feat: implement auto-close for PRs with negative reviews

### DIFF
--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -58,6 +58,7 @@ export function parseIniFile(content) {
 export async function fetchRepositoryConfig(githubClient, owner, repo) {
   const defaultConfig = {
     baseMergeTimeInHours: 240,
+    baseCloseTimeInHours: 2400,
     perCommitTimeInHours: 0,
     merge_method: 'squash',
   };
@@ -118,6 +119,13 @@ export async function fetchRepositoryConfig(githubClient, owner, repo) {
       const value = parseFloat(defaultSection.perCommitTimeInHours);
       if (!isNaN(value) && value >= 0) {
         config.perCommitTimeInHours = value;
+      }
+    }
+
+    if (defaultSection.baseCloseTimeInHours) {
+      const value = parseFloat(defaultSection.baseCloseTimeInHours);
+      if (!isNaN(value) && value >= 0) {
+        config.baseCloseTimeInHours = value;
       }
     }
 

--- a/src/helpers/githubApp.js
+++ b/src/helpers/githubApp.js
@@ -59,6 +59,24 @@ export async function mergePullRequestApp(
   }
 }
 
+export async function closePullRequestApp(installationId, owner, repo, number) {
+  const octokit = await getInstallationOctokit(installationId);
+  try {
+    return await octokit.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: number,
+      state: 'closed',
+    });
+  } catch (error) {
+    console.error(
+      `Failed to close PR ${owner}/${repo}#${number}:`,
+      error.message
+    );
+    throw error;
+  }
+}
+
 export async function setCommitStatusApp(
   installationId,
   owner,


### PR DESCRIPTION
## Summary

Extends worlddriven with symmetric auto-close functionality to complement auto-merge. PRs with sustained negative reviews will now automatically close after an extended period, providing democratic rejection while maintaining the system's forgiving nature.

## Key Features

**Symmetric Design:**
- Positive coefficient (≥ 0) → auto-merge path
- Negative coefficient (< 0) → auto-close path
- Same timer reset mechanism (commits reset countdown)

**More Forgiving:**
- Merge default: 10 days
- Close default: 100 days (10× more patient with rejection)

**Formula:**
```
Merge: mergeDuration = (1 - coefficient) × baseMergeTime
Close: closeDuration = (1 + coefficient) × baseCloseTime
```

## Examples

| Coefficient | Action | Timeline |
|------------|--------|----------|
| +1.0 | Merge immediately | 0 days |
| +0.5 | Merge at 50% | 5 days |
| 0.0 | Merge at base | 10 days |
| -0.5 | Close at 50% | 50 days |
| -1.0 | Close immediately | 0 days |

## Configuration

New option in `.worlddriven.ini`:
```ini
[DEFAULT]
baseCloseTimeInHours = 2400  # 100 days (default)
```

## Implementation Details

- **Time Calculation**: Split merge/close paths in `calculateTimeMetrics()`
- **GitHub API**: Added `closePullRequest()` with hybrid auth support
- **Status Display**: Shows "Close at YYYY-MM-DD" for negative coefficients
- **Processor**: Handles close action with proper logging and comments

## Use Cases

**Solves:**
- Stale PR accumulation (like #156, #157 - would've auto-closed years ago)
- Spam/low-quality submissions
- PRs with sustained rejection consensus

**Prevents:**
- Manual intervention for clearly rejected PRs
- Endless "zombie" PRs that never get addressed

## Testing

- ✅ 5 comprehensive new tests for auto-close logic
- ✅ All 109 tests passing
- ✅ Covers edge cases (coefficient -1.0, -0.5, custom config)
- ✅ Timer reset verification
- ✅ Status display validation

## Breaking Changes

None. This is purely additive - existing merge behavior unchanged.