### PR TITLE
chore: migrate deployment from vogt to server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
           echo "Triggering deployment for commit ${{ github.sha }}"
 
           response=$(curl -s -w "%{http_code}" -o response.json \
-            -X POST https://sumalyze.tooangel.com/deploy/worlddriven \
+            -X POST https://server.tooangel.com/deploy/worlddriven-core \
             -H "Authorization: Bearer ${{ secrets.DEPLOY_WEBHOOK_SECRET }}" \
             -H "Content-Type: application/json" \
             -d '{


### PR DESCRIPTION
Updates deployment configuration to use the new server infrastructure.

## Changes
- Update deployment webhook endpoint from `sumalyze.tooangel.com` (vogt) to `server.tooangel.com` (server)
- Update app name from `worlddriven` to `worlddriven-core` to match the new server naming convention

## Testing
This PR includes the GitHub Actions migration from #282 and updates the deployment endpoint for the server migration.